### PR TITLE
feat(api): job posting edit

### DIFF
--- a/src/controllers/postController.js
+++ b/src/controllers/postController.js
@@ -27,14 +27,23 @@ const detailPost = async (req, res) => {
 const registerPost = async (req, res) => {
     const { title, name, position, skill, compensation, explanation, deadline } = req.body
     if( !title || !name || !skill || !compensation || !explanation || !deadline ) {
-        res.status(400).json({"message":"빈칸 없이 모두 입력해주세요"})
+        return res.status(400).json({"message":"빈칸 없이 모두 입력해주세요"})
     } else await postService.registerPost(title, name, position, skill, compensation, explanation, deadline);
-    res.status(200).json({"message": "채용공고 등록에 성공하였습니다!"});
+    return res.status(200).json({"message": "채용공고 등록에 성공하였습니다!"});
 };
+
+const editPost= async (req, res) => {
+    const { id, title, name, position, skill, compensation, explanation, deadline } = req.body
+    if( !id || !title || !name || !skill || !compensation || !explanation || !deadline ) {
+        return res.status(400).json({"message":"빈칸 없이 모두 입력해주세요"})
+    } else await postService.editPost(id, title, name, position, skill, compensation, explanation, deadline);
+    return res.status(200).json({"message": "edit success"});
+}
 
 module.exports = {
     listPost,
     searchPost,
     detailPost,
-    registerPost
+    registerPost,
+    editPost
 }

--- a/src/models/postDao.js
+++ b/src/models/postDao.js
@@ -128,6 +128,34 @@ const registerPost = async (title, corperationId, positionId, skillId, compensat
     )
 }
 
+const editPost = async (id, title, getCorpId, getPositionId, getSkillId, compensation, explanation, deadline) => {
+    return await AppDataSource.query(
+        `
+        UPDATE posts
+        SET 
+        title = "${title}",
+        corp_id = ${getCorpId},
+        position_id = ${getPositionId},
+        skill_id = ${getSkillId},
+        compensation = ${compensation},
+        explanation = "${explanation}",
+        deadline = "${deadline}"
+        WHERE id=${id}
+        `
+    )
+}
+
+const checkPost = async (id) => {
+    return await AppDataSource.query(
+        `
+        SELECT EXISTS (
+            SELECT * FROM posts p
+            WHERE p.id=${id}
+        )
+        `
+    )
+}
+
 module.exports = {
     listPost,
     searchPost,
@@ -139,5 +167,7 @@ module.exports = {
     getCorperationId,
     getPositionId,
     getSkillId,
-    registerPost
+    registerPost,
+    editPost,
+    checkPost
 }

--- a/src/routes/postRouter.js
+++ b/src/routes/postRouter.js
@@ -11,4 +11,6 @@ router.get("/detail", errorHandler(postController.detailPost)); // 상세정보
 
 router.post("/register", errorHandler(postController.registerPost)); //채용공고 등록
 
+router.put("/", errorHandler(postController.editPost)); //채용공고 수정
+
 module.exports = { router };

--- a/src/services/postService.js
+++ b/src/services/postService.js
@@ -1,6 +1,7 @@
 const postDao = require("../models/postDao");
 const Error = require("../middlewares/errorConstructor");
 const information = require("../utils/getId");
+const postCheck = require("../utils/existCheck");
 
 const listPost = async() => {
     const getList = await postDao.listPost();
@@ -35,10 +36,22 @@ const registerPost = async (title, name, position, skill, compensation, explanat
     return true;
 }
 
+const editPost = async (id, title, name, position, skill, compensation, explanation, deadline) => {
+    await postCheck.checkPost(id);
+    const corperationId = await information.getInformationIdByName(name);
+    const positionId = await information.getPositionId(position);
+    const skillId = await information.getSkillId(skill);
+
+    await postDao.editPost(id, title, corperationId, positionId, skillId, compensation, explanation, deadline);
+    return true;
+}
+
+
 
 module.exports = {
     listPost,
     searchPost,
     detailPost,
-    registerPost
+    registerPost,
+    editPost
 }

--- a/src/utils/existCheck.js
+++ b/src/utils/existCheck.js
@@ -1,0 +1,27 @@
+const postDao = require("../models/postDao");
+const Error = require("../middlewares/errorConstructor");
+
+const checkPost = async function(id) {
+    const checkPostExist = await postDao.checkPost(id);
+    const checkResult = Number(Object.values(checkPostExist[0])[0]);
+    if (checkResult === 0) {
+        throw new Error("POST NOT EXISTS", 400);
+    } else return checkResult;
+};
+
+const checkApply = async function(id, userId) {
+    const checkApply = await postDao.checkApply(id, userId);
+    const checkResult = await Number(Object.values(checkApply[0])[0]);
+    if(checkResult !== 1) {
+        await postDao.applyPost(id, userId);
+        return true;
+    } else {
+        await postDao.applyDelete(id, userId);
+        return false;
+    }
+};
+
+module.exports = {
+    checkPost,
+    checkApply
+}


### PR DESCRIPTION
# 구현사항

### 채용공고 수정 API
- 채용공고 등록과 동일한 방식으로 게시글 내용 입력 시 해당 게시글 수정
- 추가적으로 게시글을 식별할 수 있도록 게시글 id도 body 전송
- PUT method 사용하였기 때문에 게시글의 모든 내용을 입력하지 않으면 수정이 불가능도록 구현
- 성공시 상태코드 200 반환