### PR TITLE
feat(api): job post apply and renounce

### DIFF
--- a/src/controllers/postController.js
+++ b/src/controllers/postController.js
@@ -44,7 +44,17 @@ const deletePost= async (req, res) => {
     const { id } = req.query
     const result = await postService.deletePost(id);
     if (result === true){
-        res.status(204).json({});
+        return res.status(204).json({});
+    }
+}
+
+const applyPost = async (req, res) => {
+    const { id, userId } = req.body
+    const applyPost = await postService.applyPost(id, userId);
+    if( applyPost === true){
+        return res.status(200).json({"message":"success apply", "post_id": id, "user_id": userId });
+    } else {
+        return res.status(200).json({"message":"success delete apply", "post_id": id, "user_id": userId});
     }
 }
 
@@ -54,5 +64,6 @@ module.exports = {
     detailPost,
     registerPost,
     editPost,
-    deletePost
+    deletePost,
+    applyPost
 }

--- a/src/models/postDao.js
+++ b/src/models/postDao.js
@@ -164,6 +164,31 @@ const deletePost = async (id) => {
     )
 }
 
+const applyPost = async (id, userId) => {
+    return await AppDataSource.query(
+        `
+        INSERT INTO applications (post_id, user_id)
+        VALUES (${id}, ${userId})
+        `
+    )
+}
+
+const checkApply = async (id, userId) => {
+    return await AppDataSource.query(
+        `
+        SELECT EXISTS (SELECT * FROM applications WHERE user_id=${userId} AND post_id=${id})
+        `
+    )
+}
+
+const applyDelete = async (id, userId) => {
+    return await AppDataSource.query(
+        `
+        DELETE FROM applications WHERE post_id=${id} AND user_id=${userId}
+        `
+    )
+}
+
 module.exports = {
     listPost,
     searchPost,
@@ -178,5 +203,8 @@ module.exports = {
     registerPost,
     editPost,
     checkPost,
-    deletePost
+    deletePost,
+    applyPost,
+    checkApply,
+    applyDelete
 }

--- a/src/routes/postRouter.js
+++ b/src/routes/postRouter.js
@@ -15,4 +15,6 @@ router.put("/", errorHandler(postController.editPost)); //채용공고 수정
 
 router.delete("/", errorHandler(postController.deletePost)); // 채용공고 삭제
 
+router.post("/apply", errorHandler(postController.applyPost)) // 채용공고 지원
+
 module.exports = { router };

--- a/src/services/postService.js
+++ b/src/services/postService.js
@@ -52,11 +52,21 @@ const deletePost = async (id) => {
     return true;
 }
 
+const applyPost = async (id, userId) => {
+    const result = await postCheck.checkApply(id, userId);
+    if (result === true) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 module.exports = {
     listPost,
     searchPost,
     detailPost,
     registerPost,
     editPost,
-    deletePost
+    deletePost,
+    applyPost
 }


### PR DESCRIPTION
# 구현사항

### 채용공고 지원 API 구현
- userId, id(채용 공고글 id) 를 전송시 applications table에 정보가 삽입됨
- application table UNIAUE KEY 설정으로 중복 지원이 불가능
- 같은 엔드 포인트에 동일한 userId, id를 재 전송시 취소로 간주하여 applications 테이블에서 삭제하도록 기능 구현